### PR TITLE
chore: normalize benchmarks.

### DIFF
--- a/fibonacci-nodejs-cpu-push/index.js
+++ b/fibonacci-nodejs-cpu-push/index.js
@@ -1,13 +1,12 @@
 const pyroscope = require('@pyroscope/nodejs');
 
 function fibonacci(n) {
-    if ( n == 1 ) { return 1; }
-    if ( n == 2 ) { return 1; }
+    if ( n < 2 ) { return n; }
 
     return fibonacci(n - 1) + fibonacci(n - 2);
 }
 
-const num = 46;
+const num = 49;
 
 if ( process.env['PYROSCOPE_AGENT_BENCHMARK_ENABLE_PROFILING'] ) {
     pyroscope.init({server: 'http://ingester:4000', autoStart: false, name: 'fibonacci-nodejs-cpu-push'});
@@ -15,9 +14,7 @@ if ( process.env['PYROSCOPE_AGENT_BENCHMARK_ENABLE_PROFILING'] ) {
     fibonacci(num);
     setTimeout(() => { console.log("Disabling"); pyroscope.stopCpuProfiling()} );
     process.exit(0);
-} else {    
-    pyroscope.init({autoStart: false});
+} else {
     fibonacci(num);
     process.exit(0);
-
 }

--- a/fibonacci-nodejs-mem-push/index.js
+++ b/fibonacci-nodejs-mem-push/index.js
@@ -1,23 +1,20 @@
 const pyroscope = require('@pyroscope/nodejs');
 
 function fibonacci(n) {
-    if ( n == 1 ) { return 1; }
-    if ( n == 2 ) { return 1; }
+    if ( n < 2 ) { return n; }
 
     return fibonacci(n - 1) + fibonacci(n - 2);
 }
 
-const num = 48;
+const num = 49;
 
 if ( process.env['PYROSCOPE_AGENT_BENCHMARK_ENABLE_PROFILING'] ) {
-    pyroscope.init({server: 'http://ingester:4000', autoStart: false, name: 'fibonacci-nodejs-cpu-push'});
+    pyroscope.init({server: 'http://ingester:4000', autoStart: false, name: 'fibonacci-nodejs-mem-push'});
     pyroscope.startHeapProfiling();
     fibonacci(num);
     setTimeout(() => { console.log("Disabling"); pyroscope.stopHeapProfiling()} );
     process.exit(0);
-} else {    
-    pyroscope.init({autoStart: false});
+} else {
     fibonacci(num);
     process.exit(0);
-
 }

--- a/fibonacci-ruby-cpu-push/fib.rb
+++ b/fibonacci-ruby-cpu-push/fib.rb
@@ -15,4 +15,4 @@ if ENV["PYROSCOPE_AGENT_BENCHMARK_ENABLE_PROFILING"] then
   end
 end
 
-fib(43)
+fib(44)

--- a/fibonacci-rust-cpu-push/src/main.rs
+++ b/fibonacci-rust-cpu-push/src/main.rs
@@ -10,7 +10,7 @@ fn fib(n: i64) -> i64 {
 }
 
 fn run() {
-    fib(50);
+    fib(51);
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
- Use the same fib implementation in nodejs as in the other languages.
- Increase the fib value for implementations taking less <= 40s.